### PR TITLE
feat(api): 为阅读app设置token过期时间

### DIFF
--- a/api/internal/util/httpjwt.go
+++ b/api/internal/util/httpjwt.go
@@ -91,9 +91,18 @@ func RespondLogout(w http.ResponseWriter) error {
 	return RespondText(w, "")
 }
 
+func tokenTTLFor(app string) time.Duration {
+	switch app {
+	case "legado":
+		return time.Hour * 24 * 100
+	default:
+		return AccessTokenLifetime
+	}
+}
+
 func issueAccessToken(app string, username string, role string, createdAt time.Time) (string, error) {
 	issuedAt := time.Now()
-	expiresAt := issuedAt.Add(AccessTokenLifetime)
+	expiresAt := issuedAt.Add(tokenTTLFor(app))
 
 	claims := accessClaim{
 		RegisteredClaims: jwt.RegisteredClaims{


### PR DESCRIPTION
为特定客户端（如"legado"）设置专属的 token 过期时间，其他客户端使用默认有效期。