### PR TITLE
fix: 开发环境下登录会跳转到生产域名

### DIFF
--- a/api/internal/service/auth.go
+++ b/api/internal/service/auth.go
@@ -135,7 +135,7 @@ func (s *authService) Register(w http.ResponseWriter, r *http.Request) error {
 		},
 	)
 
-	return util.RespondAuthTokens(w, util.TokenOptions{
+	return util.RespondAuthTokens(w, r, util.TokenOptions{
 		App:              req.App,
 		Username:         user.Username,
 		Role:             user.Role,
@@ -207,7 +207,7 @@ func (s *authService) Login(w http.ResponseWriter, r *http.Request) error {
 			Ip:         util.GetRealIp(r),
 		},
 	)
-	return util.RespondAuthTokens(w, util.TokenOptions{
+	return util.RespondAuthTokens(w, r, util.TokenOptions{
 		App:              req.App,
 		Username:         user.Username,
 		Role:             user.Role,
@@ -235,7 +235,7 @@ func (s *authService) Refresh(w http.ResponseWriter, r *http.Request) error {
 	user.LastLogin = time.Now()
 	s.userRepo.UpdateLastLogin(user)
 
-	return util.RespondAuthTokens(w, util.TokenOptions{
+	return util.RespondAuthTokens(w, r, util.TokenOptions{
 		App:              r.URL.Query().Get("app"),
 		Username:         user.Username,
 		Role:             user.Role,
@@ -264,7 +264,7 @@ func (s *authService) Logout(w http.ResponseWriter, r *http.Request) error {
 		},
 	)
 
-	return util.RespondLogout(w)
+	return util.RespondLogout(w, r)
 }
 
 func (s *authService) sendOtpEmail(otpType string, email string, otp string) error {

--- a/api/internal/util/httpjwt.go
+++ b/api/internal/util/httpjwt.go
@@ -94,7 +94,7 @@ type TokenOptions struct {
 	WithRefreshToken bool
 }
 
-func RespondAuthTokens(w http.ResponseWriter, opts TokenOptions) error {
+func RespondAuthTokens(w http.ResponseWriter, r *http.Request, opts TokenOptions) error {
 	policy := getTokenPolicy(opts.App)
 
 	if opts.WithRefreshToken && policy.RefreshTokenLifetime > 0 {
@@ -102,7 +102,7 @@ func RespondAuthTokens(w http.ResponseWriter, opts TokenOptions) error {
 		if err != nil {
 			return err
 		}
-		attachRefreshToken(w, refreshToken, int(policy.RefreshTokenLifetime.Seconds()))
+		attachRefreshToken(w, r, refreshToken, int(policy.RefreshTokenLifetime.Seconds()))
 	}
 	accessToken, err := issueAccessToken(opts, policy)
 	if err != nil {
@@ -111,8 +111,8 @@ func RespondAuthTokens(w http.ResponseWriter, opts TokenOptions) error {
 	return RespondText(w, accessToken)
 }
 
-func RespondLogout(w http.ResponseWriter) error {
-	attachRefreshToken(w, "", 0)
+func RespondLogout(w http.ResponseWriter, r *http.Request) error {
+	attachRefreshToken(w, r, "", 0)
 	return RespondText(w, "")
 }
 
@@ -165,7 +165,7 @@ func issueRefreshToken(opts TokenOptions, policy TokenPolicy) (string, error) {
 
 }
 
-func attachRefreshToken(w http.ResponseWriter, token string, maxAge int) {
+func attachRefreshToken(w http.ResponseWriter, r *http.Request, token string, maxAge int) {
 	cookie := &http.Cookie{
 		Name:     RefreshTokenCookieName,
 		Value:    token,
@@ -174,6 +174,11 @@ func attachRefreshToken(w http.ResponseWriter, token string, maxAge int) {
 		HttpOnly: true,
 		Secure:   true,
 		SameSite: http.SameSiteStrictMode,
+	}
+	// 本地开发时不同端口共享 cookie
+	if strings.HasPrefix(r.Host, "localhost") || strings.HasPrefix(r.Host, "127.0.0.1") {
+		cookie.Domain = "localhost"
+		cookie.Secure = false
 	}
 	http.SetCookie(w, cookie)
 }

--- a/web/src/ui/util.ts
+++ b/web/src/ui/util.ts
@@ -32,8 +32,9 @@ export const Validator = {
 
 export function onLoginSuccess() {
   if (window.parent === window) {
-    // 如果不是在 iframe 中打开的，直接跳转到主页
-    window.location.href = 'https://n.novelia.cc';
+    // 本地开发跳转到主前端 dev server，生产环境跳转到 n.novelia.cc
+    const target = import.meta.env.DEV ? 'http://localhost:5173' : 'https://n.novelia.cc';
+    window.location.href = target;
   } else {
     // 如果是在 iframe 中打开的，发送消息给父窗口
     window.parent.postMessage({ type: 'login_success' }, '*');

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -27,9 +27,10 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': '*',
-        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Allow-Origin': 'http://localhost:5173',
+        'Access-Control-Allow-Credentials': 'true',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
       },
       proxy: {
         '/api': {


### PR DESCRIPTION
## 问题

`onLoginSuccess()` 中跳转目标硬编码为 `https://n.novelia.cc`，导致本地开发环境登录后也跳转到生产域名。

## 修复

用 Vite 内置的 `import.meta.env.DEV` 区分环境：

- `vite`（开发）→ 跳 `http://localhost:5173`
- `vite build`（生产）→ 跳 `https://n.novelia.cc`

`DEV` 是 Vite 编译时常量，跨平台一致，不依赖运行时判断。